### PR TITLE
chore: export Session.Start method back for use in oss pyroscope

### DIFF
--- a/pyroscope/api.go
+++ b/pyroscope/api.go
@@ -83,7 +83,7 @@ func Start(cfg Config) (*Profiler, error) {
 		return nil, fmt.Errorf("new session: %w", err)
 	}
 	uploader.Start()
-	if err = s.start(); err != nil {
+	if err = s.Start(); err != nil {
 		return nil, fmt.Errorf("start session: %w", err)
 	}
 

--- a/pyroscope/session.go
+++ b/pyroscope/session.go
@@ -200,7 +200,7 @@ func copyBuf(b []byte) []byte {
 	return r
 }
 
-func (ps *Session) start() error {
+func (ps *Session) Start() error {
 	t := ps.truncatedTime()
 	ps.reset(t, t)
 


### PR DESCRIPTION
It was a mistake to make it not exported - it is used in OSS
https://github.com/pyroscope-io/client/commit/34083a24bffb2b64a015a39ad38d39308f7515dc#diff-4efaa3f45c1626d48deeddb05bb5739271d1d40024c8a63d05bae7ca04202952R147-R149