### PR TITLE
feat: add upload rate config support

### DIFF
--- a/pyroscope/api.go
+++ b/pyroscope/api.go
@@ -22,6 +22,7 @@ type Config struct {
 	DisableAutomaticResets bool // disable automatic profiler reset every 10 seconds. Reset manually by calling Flush method
 	// Deprecated: the field is ignored and does nothing
 	DisableCumulativeMerge bool
+	UploadRate             uint8 // data upload frequency: every 10 seconds by default
 }
 
 type Profiler struct {
@@ -36,6 +37,9 @@ func Start(cfg Config) (*Profiler, error) {
 	}
 	if cfg.SampleRate == 0 {
 		cfg.SampleRate = DefaultSampleRate
+	}
+	if cfg.UploadRate == 0 {
+		cfg.UploadRate = DefaultUploadRate
 	}
 	if cfg.Logger == nil {
 		cfg.Logger = noopLogger
@@ -68,7 +72,7 @@ func Start(cfg Config) (*Profiler, error) {
 		DisableGCRuns:          cfg.DisableGCRuns,
 		DisableAutomaticResets: cfg.DisableAutomaticResets,
 		SampleRate:             cfg.SampleRate,
-		UploadRate:             10 * time.Second,
+		UploadRate:             time.Duration(cfg.UploadRate) * time.Second,
 	}
 
 	cfg.Logger.Infof("starting profiling session:")

--- a/pyroscope/api.go
+++ b/pyroscope/api.go
@@ -22,7 +22,7 @@ type Config struct {
 	DisableAutomaticResets bool // disable automatic profiler reset every 10 seconds. Reset manually by calling Flush method
 	// Deprecated: the field is ignored and does nothing
 	DisableCumulativeMerge bool
-	UploadRate             uint8 // data upload frequency: every 10 seconds by default
+	UploadRate             time.Duration // data upload frequency: every 10 seconds by default
 }
 
 type Profiler struct {
@@ -72,7 +72,7 @@ func Start(cfg Config) (*Profiler, error) {
 		DisableGCRuns:          cfg.DisableGCRuns,
 		DisableAutomaticResets: cfg.DisableAutomaticResets,
 		SampleRate:             cfg.SampleRate,
-		UploadRate:             time.Duration(cfg.UploadRate) * time.Second,
+		UploadRate:             cfg.UploadRate,
 	}
 
 	cfg.Logger.Infof("starting profiling session:")

--- a/pyroscope/types.go
+++ b/pyroscope/types.go
@@ -1,5 +1,7 @@
 package pyroscope
 
+import "time"
+
 type ProfileType string
 
 // Logger is an interface that library users can use
@@ -23,7 +25,7 @@ const (
 	ProfileBlockCount    ProfileType = "block_count"
 	ProfileBlockDuration ProfileType = "block_duration"
 	DefaultSampleRate                = 100
-	DefaultUploadRate                = 10
+	DefaultUploadRate                = time.Second * 10
 )
 
 var DefaultProfileTypes = []ProfileType{

--- a/pyroscope/types.go
+++ b/pyroscope/types.go
@@ -23,6 +23,7 @@ const (
 	ProfileBlockCount    ProfileType = "block_count"
 	ProfileBlockDuration ProfileType = "block_duration"
 	DefaultSampleRate                = 100
+	DefaultUploadRate                = 10
 )
 
 var DefaultProfileTypes = []ProfileType{


### PR DESCRIPTION
By default, data is uploaded every 10 seconds, but sometimes you need to customize the upload frequency to control the number of data collection.